### PR TITLE
Add postinstall script for bun installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@mcp-demos/excalidraw-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-demos/excalidraw-server",
-      "version": "0.1.0",
+      "version": "0.2.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.0",
@@ -35,6 +36,19 @@
         "typescript": "^5.9.3",
         "vite": "^6.0.0",
         "vite-plugin-singlefile": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "@oven/bun-darwin-aarch64": "^1.2.21",
+        "@oven/bun-darwin-x64": "^1.2.21",
+        "@oven/bun-darwin-x64-baseline": "^1.2.21",
+        "@oven/bun-linux-aarch64": "^1.2.21",
+        "@oven/bun-linux-aarch64-musl": "^1.2.21",
+        "@oven/bun-linux-x64": "^1.2.21",
+        "@oven/bun-linux-x64-baseline": "^1.2.21",
+        "@oven/bun-linux-x64-musl": "^1.2.21",
+        "@oven/bun-linux-x64-musl-baseline": "^1.2.21",
+        "@oven/bun-windows-x64": "^1.2.21",
+        "@oven/bun-windows-x64-baseline": "^1.2.21"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2491,7 +2505,7 @@
       "version": "19.2.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2501,7 +2515,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3084,7 +3098,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -4145,16 +4159,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     }
   },
   "scripts": {
+    "postinstall": "node scripts/setup-bun.mjs || echo 'setup-bun.mjs failed or not available'",
     "build": "tsc --noEmit && cross-env INPUT=mcp-app.html vite build && tsc -p tsconfig.server.json && bun build server.ts --outdir dist --target node && bun build main.ts --outfile dist/index.js --target node --external \"./server.js\" --banner \"#!/usr/bin/env node\"",
     "watch": "cross-env INPUT=mcp-app.html vite build --watch",
     "serve": "bun --watch main.ts",
@@ -50,5 +51,18 @@
     "typescript": "^5.9.3",
     "vite": "^6.0.0",
     "vite-plugin-singlefile": "^2.3.0"
+  },
+  "optionalDependencies": {
+    "@oven/bun-darwin-aarch64": "^1.2.21",
+    "@oven/bun-darwin-x64": "^1.2.21",
+    "@oven/bun-darwin-x64-baseline": "^1.2.21",
+    "@oven/bun-linux-aarch64": "^1.2.21",
+    "@oven/bun-linux-aarch64-musl": "^1.2.21",
+    "@oven/bun-linux-x64": "^1.2.21",
+    "@oven/bun-linux-x64-baseline": "^1.2.21",
+    "@oven/bun-linux-x64-musl": "^1.2.21",
+    "@oven/bun-linux-x64-musl-baseline": "^1.2.21",
+    "@oven/bun-windows-x64": "^1.2.21",
+    "@oven/bun-windows-x64-baseline": "^1.2.21"
   }
 }

--- a/scripts/setup-bun.mjs
+++ b/scripts/setup-bun.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+// Immediate log to verify script execution
+console.log("[setup-bun] Script loaded");
+
+/**
+ * Postinstall script to set up bun from platform-specific optional dependencies.
+ * Handles Windows ARM64 by downloading x64-baseline via emulation.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  symlinkSync,
+  unlinkSync,
+  copyFileSync,
+  chmodSync,
+  writeFileSync,
+} from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+import { get } from "https";
+import { createGunzip } from "zlib";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, "..");
+const nodeModules = join(projectRoot, "node_modules");
+const binDir = join(nodeModules, ".bin");
+
+const os = process.platform;
+const arch = process.arch;
+const isWindows = os === "win32";
+const bunExe = isWindows ? "bun.exe" : "bun";
+
+// Detect libc type on Linux (glibc vs musl)
+function detectLibc() {
+  if (os !== "linux") return null;
+
+  // Check for musl-specific loader
+  const muslLoaders = [
+    `/lib/ld-musl-${arch === "arm64" ? "aarch64" : "x86_64"}.so.1`,
+    "/lib/ld-musl-x86_64.so.1",
+    "/lib/ld-musl-aarch64.so.1",
+  ];
+
+  for (const loader of muslLoaders) {
+    if (existsSync(loader)) {
+      console.log(`  Detected musl libc (found ${loader})`);
+      return "musl";
+    }
+  }
+
+  // Default to glibc on Linux
+  console.log("  Detected glibc (no musl loader found)");
+  return "glibc";
+}
+
+// Platform to package mapping (matches @oven/bun-* package names)
+// For Linux, separate glibc and musl packages
+const platformPackages = {
+  darwin: {
+    arm64: ["bun-darwin-aarch64"],
+    x64: ["bun-darwin-x64", "bun-darwin-x64-baseline"],
+  },
+  linux: {
+    arm64: {
+      glibc: ["bun-linux-aarch64"],
+      musl: ["bun-linux-aarch64-musl"],
+    },
+    x64: {
+      glibc: ["bun-linux-x64", "bun-linux-x64-baseline"],
+      musl: ["bun-linux-x64-musl", "bun-linux-x64-musl-baseline"],
+    },
+  },
+  win32: {
+    x64: ["bun-windows-x64", "bun-windows-x64-baseline"],
+    arm64: ["bun-windows-x64-baseline"], // x64 runs via emulation on ARM64
+  },
+};
+
+function findBunBinary() {
+  let packages = platformPackages[os]?.[arch];
+
+  // For Linux, select packages based on libc type
+  if (os === "linux" && packages && typeof packages === "object") {
+    const libc = detectLibc();
+    packages = packages[libc] || [];
+  }
+
+  packages = packages || [];
+  console.log(
+    `Looking for bun packages: ${packages.join(", ") || "(none for this platform)"}`,
+  );
+
+  for (const pkg of packages) {
+    const binPath = join(nodeModules, "@oven", pkg, "bin", bunExe);
+    console.log(`  Checking: ${binPath}`);
+    if (existsSync(binPath)) {
+      console.log(`  Found bun at: ${binPath}`);
+      return binPath;
+    } else {
+      console.log(`  Not found`);
+    }
+  }
+
+  return null;
+}
+
+async function downloadBunForWindowsArm64() {
+  // Windows ARM64 can run x64 binaries via emulation
+  const pkg = "bun-windows-x64-baseline";
+  const version = "1.2.21";
+  const url = `https://registry.npmjs.org/@oven/${pkg}/-/${pkg}-${version}.tgz`;
+  const destDir = join(nodeModules, "@oven", pkg);
+
+  console.log(`Downloading ${pkg} for Windows ARM64 emulation...`);
+
+  return new Promise((resolve, reject) => {
+    get(url, (response) => {
+      if (response.statusCode === 302 || response.statusCode === 301) {
+        get(response.headers.location, handleResponse).on("error", reject);
+      } else {
+        handleResponse(response);
+      }
+
+      function handleResponse(res) {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Failed to download: ${res.statusCode}`));
+          return;
+        }
+
+        const chunks = [];
+        const gunzip = createGunzip();
+
+        res.pipe(gunzip);
+
+        gunzip.on("data", (chunk) => chunks.push(chunk));
+        gunzip.on("end", () => {
+          try {
+            extractTar(Buffer.concat(chunks), destDir);
+            const binPath = join(destDir, "bin", bunExe);
+            if (existsSync(binPath)) {
+              resolve(binPath);
+            } else {
+              reject(new Error("Binary not found after extraction"));
+            }
+          } catch (err) {
+            reject(err);
+          }
+        });
+        gunzip.on("error", reject);
+      }
+    }).on("error", reject);
+  });
+}
+
+function extractTar(buffer, destDir) {
+  // Simple tar extraction (512-byte blocks)
+  let offset = 0;
+  while (offset < buffer.length) {
+    const name = buffer
+      .toString("utf-8", offset, offset + 100)
+      .replace(/\0.*$/, "")
+      .replace("package/", "");
+    const size = parseInt(
+      buffer.toString("utf-8", offset + 124, offset + 136).trim(),
+      8,
+    );
+
+    offset += 512;
+
+    if (!isNaN(size) && size > 0 && name) {
+      const filePath = join(destDir, name);
+      const fileDir = dirname(filePath);
+      if (!existsSync(fileDir)) {
+        mkdirSync(fileDir, { recursive: true });
+      }
+      const content = buffer.subarray(offset, offset + size);
+      writeFileSync(filePath, content);
+
+      // Make executable
+      if (name.endsWith(bunExe) || name === "bin/bun") {
+        try {
+          chmodSync(filePath, 0o755);
+        } catch {}
+      }
+
+      offset += Math.ceil(size / 512) * 512;
+    }
+  }
+}
+
+function setupBinLink(bunPath) {
+  if (!existsSync(binDir)) {
+    mkdirSync(binDir, { recursive: true });
+  }
+
+  const bunLink = join(binDir, bunExe);
+  const bunxLink = join(binDir, isWindows ? "bunx.exe" : "bunx");
+
+  // Remove existing links
+  for (const link of [bunLink, bunxLink]) {
+    try {
+      unlinkSync(link);
+    } catch {}
+  }
+
+  if (isWindows) {
+    // On Windows, copy the binary (symlinks may not work without admin)
+    copyFileSync(bunPath, bunLink);
+    copyFileSync(bunPath, bunxLink);
+  } else {
+    // On Unix, use symlinks
+    symlinkSync(bunPath, bunLink);
+    symlinkSync(bunPath, bunxLink);
+  }
+
+  console.log(`Bun linked to: ${bunLink}`);
+}
+
+// Force immediate output
+process.stdout.write("[setup-bun] Script starting...\n");
+
+async function main() {
+  process.stdout.write(`[setup-bun] Setting up bun for ${os} ${arch}...\n`);
+  process.stdout.write(`[setup-bun] Project root: ${projectRoot}\n`);
+  process.stdout.write(`[setup-bun] Node modules: ${nodeModules}\n`);
+
+  let bunPath = findBunBinary();
+
+  if (!bunPath && os === "win32" && arch === "arm64") {
+    try {
+      bunPath = await downloadBunForWindowsArm64();
+    } catch (err) {
+      console.error("Failed to download bun for Windows ARM64:", err.message);
+    }
+  }
+
+  if (!bunPath) {
+    console.log("No bun binary found in optional dependencies.");
+    console.log("Bun will need to be installed separately.");
+    console.log("See: https://bun.sh/docs/installation");
+    process.exit(0); // Don't fail the install
+  }
+
+  try {
+    setupBinLink(bunPath);
+
+    // Verify installation
+    const result = spawnSync(bunPath, ["--version"], { encoding: "utf-8" });
+    if (result.status === 0) {
+      console.log(`Bun ${result.stdout.trim()} installed successfully!`);
+    }
+  } catch (err) {
+    console.error("Failed to set up bun:", err.message);
+    process.exit(0); // Don't fail the install
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(0); // Don't fail the install
+});


### PR DESCRIPTION
### Issue
Cant run `npm run serve` without preinstalled bun

<img width="549" height="316" alt="image" src="https://github.com/user-attachments/assets/2d6dbcea-e241-42c7-b755-ea4bb7e235ca" />


### Solution
Introduce postinstall script, same as in [ext apps](https://github.com/modelcontextprotocol/ext-apps) to install bun