### PR TITLE
Feat/vscode support

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -85,6 +85,11 @@ body {
   height: 100%;
 }
 
+/* Inline editor mode (no fullscreen available) */
+.main.inline-editor {
+  overflow: hidden;
+}
+
 /* Hide library button in fullscreen editor */
 .main.fullscreen .default-sidebar-trigger {
   display: none !important;
@@ -101,6 +106,8 @@ body {
   top: 8px;
   right: 8px;
   z-index: 100;
+  display: flex;
+  gap: 4px;
   opacity: 0;
   transition: opacity 0.2s ease;
 }
@@ -109,8 +116,8 @@ body {
   opacity: 1;
 }
 
-/* Fullscreen button */
-.fullscreen-btn {
+/* Toolbar button */
+.toolbar-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -129,14 +136,14 @@ body {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
-.fullscreen-btn:hover {
+.toolbar-btn:hover {
   color: rgba(0, 0, 0, 0.7);
   background: rgba(255, 255, 255, 0.8);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
 }
 
-/* Hide fullscreen button in fullscreen mode (host provides exit UI) */
-.main.fullscreen .fullscreen-btn {
+/* Hide toolbar button in fullscreen mode (host provides exit UI) */
+.main.fullscreen .toolbar-btn {
   display: none !important;
 }
 

--- a/src/mcp-app.tsx
+++ b/src/mcp-app.tsx
@@ -565,6 +565,8 @@ function ExcalidrawApp() {
   const [elements, setElements] = useState<any[]>([]);
   const [userEdits, setUserEdits] = useState<any[] | null>(null);
   const [containerHeight, setContainerHeight] = useState<number | null>(null);
+  const [canFullscreen, setCanFullscreen] = useState(false);
+  const [containerMaxHeight, setContainerMaxHeight] = useState<number | null>(null);
   const [editorReady, setEditorReady] = useState(false);
   const [excalidrawApi, setExcalidrawApi] = useState<any>(null);
   const [editorSettled, setEditorSettled] = useState(false);
@@ -572,6 +574,7 @@ function ExcalidrawApp() {
   const svgViewportRef = useRef<ViewportRect | null>(null);
   const elementsRef = useRef<any[]>([]);
   const checkpointIdRef = useRef<string | null>(null);
+  const lastInputRef = useRef<string | null>(null);
 
   const toggleFullscreen = useCallback(async () => {
     if (!appRef.current) return;
@@ -627,9 +630,9 @@ function ExcalidrawApp() {
     }
   }, [displayMode, containerHeight]);
 
-  // Mount editor when entering fullscreen
+  // Mount editor when entering fullscreen or when host doesn't support fullscreen
   useEffect(() => {
-    if (displayMode !== "fullscreen") {
+    if (displayMode !== "fullscreen" && canFullscreen) {
       setEditorReady(false);
       setExcalidrawApi(null);
       setEditorSettled(false);
@@ -639,10 +642,10 @@ function ExcalidrawApp() {
       await document.fonts.ready;
       setTimeout(() => setEditorReady(true), 200);
     })();
-  }, [displayMode]);
+  }, [displayMode, canFullscreen]);
 
   // After editor mounts: refresh text dimensions, then reveal
-  const mountEditor = displayMode === "fullscreen" && inputIsFinal && elements.length > 0 && editorReady;
+  const mountEditor = (displayMode === "fullscreen" || !canFullscreen) && inputIsFinal && elements.length > 0 && editorReady;
   useEffect(() => {
     if (!mountEditor || !excalidrawApi) return;
     if (editorSettled) return; // already revealed, don't redo
@@ -681,13 +684,24 @@ function ExcalidrawApp() {
       appRef.current = app;
       _logFn = (msg) => { try { app.sendLog({ level: "info", logger: "FS", data: msg }); } catch {} };
 
-      // Capture initial container dimensions
-      const initDims = app.getHostContext()?.containerDimensions as any;
+      // Capture initial container dimensions and host capabilities
+      const initCtx = app.getHostContext() as any;
+      const initDims = initCtx?.containerDimensions;
       if (initDims?.height) setContainerHeight(initDims.height);
+      if (initDims?.maxHeight) setContainerMaxHeight(initDims.maxHeight);
+      if (initCtx?.availableDisplayModes) {
+        setCanFullscreen(initCtx.availableDisplayModes.includes("fullscreen"));
+      }
 
       app.onhostcontextchanged = (ctx: any) => {
         if (ctx.containerDimensions?.height) {
           setContainerHeight(ctx.containerDimensions.height);
+        }
+        if (ctx.containerDimensions?.maxHeight) {
+          setContainerMaxHeight(ctx.containerDimensions.maxHeight);
+        }
+        if (ctx.availableDisplayModes) {
+          setCanFullscreen(ctx.availableDisplayModes.includes("fullscreen"));
         }
         if (ctx.displayMode) {
           fsLog(`hostContextChanged: displayMode=${ctx.displayMode}`);
@@ -711,6 +725,9 @@ function ExcalidrawApp() {
 
       app.ontoolinput = async (input) => {
         const args = (input as any)?.arguments || input;
+        const sig = JSON.stringify(args);
+        if (lastInputRef.current === sig) return;
+        lastInputRef.current = sig;
         setInputIsFinal(true);
         setToolInput(args);
       };
@@ -718,6 +735,7 @@ function ExcalidrawApp() {
       app.ontoolresult = (result: any) => {
         const cpId = (result.structuredContent as { checkpointId?: string })?.checkpointId;
         if (cpId) {
+          if (cpId === checkpointIdRef.current) return;
           checkpointIdRef.current = cpId;
           setCheckpointId(cpId);
           // Use checkpointId as localStorage key for persisting user edits
@@ -741,11 +759,11 @@ function ExcalidrawApp() {
   if (!app) return <div className="loading">Connecting...</div>;
 
   return (
-    <main className={`main${displayMode === "fullscreen" ? " fullscreen" : ""}`} style={displayMode === "fullscreen" && containerHeight ? { height: containerHeight } : undefined}>
-      {displayMode === "inline" && (
+    <main className={`main${displayMode === "fullscreen" ? " fullscreen" : ""}${!canFullscreen && mountEditor ? " inline-editor" : ""}`} style={displayMode === "fullscreen" && containerHeight ? { height: containerHeight } : !canFullscreen && mountEditor ? { height: containerMaxHeight ?? 500 } : undefined}>
+      {displayMode === "inline" && canFullscreen && (
         <div className="toolbar">
           <button
-            className="fullscreen-btn"
+            className="toolbar-btn"
             onClick={toggleFullscreen}
             title="Enter fullscreen"
           >


### PR DESCRIPTION
# feat: VS Code host support

Add support for MCP App hosts that don't offer fullscreen mode (VS Code, etc.), while keeping full Excalidraw editing capabilities through an inline editor.

## Problem

The Excalidraw MCP App was built exclusively for Claude Desktop's fullscreen mode. In VS Code's Copilot Chat, which only supports `inline` display mode:

- The fullscreen button appeared briefly then disappeared (flicker)
- Diagrams were not interactive — no way to edit them
- Scrolling through chat re-fired `ontoolinput`/`ontoolresult` events, causing unnecessary re-renders
- Diagram state leaked across chats via a shared localStorage fallback key

## Before / After


https://github.com/user-attachments/assets/711c2bae-1b06-4c62-9a61-9ac458fbb420



https://github.com/user-attachments/assets/dc9a4265-62d5-4da4-bc04-50fd22c2a97d



## Changes

### Inline editing mode (`src/mcp-app.tsx`, `src/global.css`)

When fullscreen is unavailable, an **Edit** button replaces the Fullscreen button. Clicking it opens an Excalidraw editor overlaid on top of the SVG preview — same editing experience, no fullscreen required.

- SVG stays in the DOM during editing (`visibility: hidden`) so VS Code can measure iframe content height correctly
- Editor container uses absolute positioning to overlay the preview area
- Toolbar adapts per host: Claude gets `[Export] [Fullscreen]`, VS Code gets `[Export] [Edit]`

### Replay deduplication (`src/mcp-app.tsx`)

VS Code replays `ontoolinput` + `ontoolresult` whenever a widget scrolls into view. Without dedup, this caused re-renders and flicker. Fixed by:

- Tracking last processed input via ref — skip if elements string matches
- Tracking last checkpoint ID — skip `ontoolresult` if checkpoint hasn't changed

### Host detection & defaults (`src/mcp-app.tsx`)

- `canFullscreen` defaults to `false` (was `true`), preventing the fullscreen button from flashing on hosts that don't support it
- `onhostcontextchanged` reads `availableDisplayModes` to set `canFullscreen`, with an `else` fallback to `false`
- Storage key only set when `toolCallId` is present — no more `"default"` fallback that caused cross-chat diagram sharing

### Export without fullscreen (`src/mcp-app.tsx`)

Extracted `exportElements()` as a standalone function using `serializeAsJSON` directly, so Export works without needing the Excalidraw imperative API (which requires the editor to be mounted).

## Technical notes

- **No streaming in VS Code**: Investigation confirmed VS Code fires zero `ontoolinputpartial` events. The streaming draw-on animation only works in Claude Desktop. This is a host limitation, not fixable from the widget side.
- **React hooks order**: All hooks (`useCallback` for `toggleInlineEdit`, `toggleFullscreen`) are placed before early returns to avoid hooks-order violations that caused black-box rendering.
- **No changes to server.ts or tool definitions**: This is purely a widget-side change.
