### PR TITLE
fix: fullscreen height collapse on claude.ai web

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -82,7 +82,7 @@ body {
 }
 
 .main.fullscreen .excalidraw-container {
-  height: 100vh;
+  height: 100%;
 }
 
 /* Hide library button in fullscreen editor */
@@ -92,7 +92,7 @@ body {
 
 /* Contain SVG inside fullscreen viewport (not cover) */
 .main.fullscreen .svg-wrapper svg {
-  max-height: 100vh;
+  max-height: 100%;
 }
 
 /* Toolbar - appears on hover */
@@ -251,7 +251,7 @@ body {
 }
 
 .main.fullscreen .html-container {
-  height: 100vh;
+  height: 100%;
 }
 
 /* Export modal overlay */

--- a/src/mcp-app.html
+++ b/src/mcp-app.html
@@ -20,7 +20,6 @@
   <link rel="stylesheet" href="/src/global.css">
 </head>
 <body>
-  <div id="root"></div>
   <script type="module" src="/src/mcp-app.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes fullscreen mode collapsing to 150px on claude.ai web (works fine on Electron/Desktop).

## Root cause
`position: fixed` takes elements out of document flow, so body height = 0 in iframes. `100vh` doesn't work correctly in iframe contexts on the web.

## Fix
- Use `containerDimensions.height` from host context (`onhostcontextchanged`) instead of `100vh`
- Set explicit height on `html`/`body` in fullscreen mode
- Remove `#root` div — render React directly to `body` (one fewer layer in the height chain)
- Replace all CSS `100vh` with `100%` in fullscreen rules (children inherit from parent with explicit height)