### PR TITLE
Harden checkpoint store against path traversal and resource exhaustion

### DIFF
--- a/src/checkpoint-store.ts
+++ b/src/checkpoint-store.ts
@@ -2,6 +2,25 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
+/** Maximum serialized checkpoint size (5 MB). */
+const MAX_CHECKPOINT_BYTES = 5 * 1024 * 1024;
+
+/** Maximum number of checkpoints kept on disk before pruning oldest. */
+const MAX_FILE_CHECKPOINTS = 100;
+
+/**
+ * Validates that a checkpoint ID is safe to use as a filename.
+ * Rejects path traversal attempts and other filesystem-unsafe characters.
+ */
+function validateCheckpointId(id: string): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    throw new Error(`Invalid checkpoint id: must be alphanumeric, hyphens, or underscores`);
+  }
+  if (id.length > 64) {
+    throw new Error(`Invalid checkpoint id: exceeds 64 character limit`);
+  }
+}
+
 export interface CheckpointStore {
   save(id: string, data: { elements: any[] }): Promise<void>;
   load(id: string): Promise<{ elements: any[] } | null>;
@@ -14,22 +33,71 @@ export class FileCheckpointStore implements CheckpointStore {
     fs.mkdirSync(this.dir, { recursive: true });
   }
   async save(id: string, data: { elements: any[] }): Promise<void> {
-    await fs.promises.writeFile(path.join(this.dir, `${id}.json`), JSON.stringify(data));
+    validateCheckpointId(id);
+    const serialized = JSON.stringify(data);
+    if (serialized.length > MAX_CHECKPOINT_BYTES) {
+      throw new Error(`Checkpoint data exceeds ${MAX_CHECKPOINT_BYTES} byte limit`);
+    }
+    const filePath = path.join(this.dir, `${id}.json`);
+    // Verify resolved path stays within checkpoint directory
+    if (!path.resolve(filePath).startsWith(path.resolve(this.dir) + path.sep)) {
+      throw new Error("Invalid checkpoint path");
+    }
+    await fs.promises.writeFile(filePath, serialized);
+    await this.pruneOldCheckpoints();
   }
   async load(id: string): Promise<{ elements: any[] } | null> {
+    validateCheckpointId(id);
+    const filePath = path.join(this.dir, `${id}.json`);
+    if (!path.resolve(filePath).startsWith(path.resolve(this.dir) + path.sep)) {
+      throw new Error("Invalid checkpoint path");
+    }
     try {
-      const raw = await fs.promises.readFile(path.join(this.dir, `${id}.json`), "utf-8");
+      const raw = await fs.promises.readFile(filePath, "utf-8");
       return JSON.parse(raw);
     } catch { return null; }
+  }
+  /** Remove oldest checkpoints when count exceeds the limit. */
+  private async pruneOldCheckpoints(): Promise<void> {
+    try {
+      const entries = await fs.promises.readdir(this.dir);
+      const jsonFiles = entries.filter(f => f.endsWith(".json"));
+      if (jsonFiles.length <= MAX_FILE_CHECKPOINTS) return;
+
+      const stats = await Promise.all(
+        jsonFiles.map(async f => ({
+          name: f,
+          mtime: (await fs.promises.stat(path.join(this.dir, f))).mtimeMs,
+        }))
+      );
+      stats.sort((a, b) => a.mtime - b.mtime);
+      const toRemove = stats.slice(0, stats.length - MAX_FILE_CHECKPOINTS);
+      await Promise.all(
+        toRemove.map(f => fs.promises.unlink(path.join(this.dir, f.name)).catch(() => {}))
+      );
+    } catch {
+      // Best-effort cleanup; don't fail the save
+    }
   }
 }
 
 const memoryStore = new Map<string, string>();
 export class MemoryCheckpointStore implements CheckpointStore {
   async save(id: string, data: { elements: any[] }): Promise<void> {
-    memoryStore.set(id, JSON.stringify(data));
+    validateCheckpointId(id);
+    const serialized = JSON.stringify(data);
+    if (serialized.length > MAX_CHECKPOINT_BYTES) {
+      throw new Error(`Checkpoint data exceeds ${MAX_CHECKPOINT_BYTES} byte limit`);
+    }
+    memoryStore.set(id, serialized);
+    // Evict oldest entries if over limit
+    if (memoryStore.size > MAX_FILE_CHECKPOINTS) {
+      const oldest = memoryStore.keys().next().value;
+      if (oldest !== undefined) memoryStore.delete(oldest);
+    }
   }
   async load(id: string): Promise<{ elements: any[] } | null> {
+    validateCheckpointId(id);
     const raw = memoryStore.get(id);
     if (!raw) return null;
     try { return JSON.parse(raw); } catch { return null; }
@@ -50,10 +118,16 @@ export class RedisCheckpointStore implements CheckpointStore {
     return this.redis;
   }
   async save(id: string, data: { elements: any[] }): Promise<void> {
+    validateCheckpointId(id);
+    const serialized = JSON.stringify(data);
+    if (serialized.length > MAX_CHECKPOINT_BYTES) {
+      throw new Error(`Checkpoint data exceeds ${MAX_CHECKPOINT_BYTES} byte limit`);
+    }
     const redis = await this.getRedis();
-    await redis.set(`cp:${id}`, JSON.stringify(data), { ex: REDIS_TTL_SECONDS });
+    await redis.set(`cp:${id}`, serialized, { ex: REDIS_TTL_SECONDS });
   }
   async load(id: string): Promise<{ elements: any[] } | null> {
+    validateCheckpointId(id);
     const redis = await this.getRedis();
     const raw = await redis.get(`cp:${id}`);
     if (!raw) return null;


### PR DESCRIPTION
## What this fixes

The checkpoint ID flows from client input directly into filesystem paths via `path.join(this.dir, id + ".json")` without sanitization. A crafted checkpoint ID containing path traversal sequences (e.g., `../../etc/cron.d/evil`) could write arbitrary JSON files outside the intended checkpoint directory.

While `save_checkpoint` and `read_checkpoint` are scoped to widget visibility (`["app"]`), the input still reaches `FileCheckpointStore` unsanitized. In HTTP/Streamable transport mode, this surface is reachable without additional authentication.

Additionally, there are no bounds on input size or checkpoint count, which could lead to disk/memory exhaustion.

I wrote about these patterns more broadly in [The MCP Ecosystem Has a Security Problem](https://medium.com/@debusinha2009/the-mcp-ecosystem-has-a-security-problem-c2f585a5bb05) -- this PR addresses the specific instances found here.

## Changes

**Path traversal prevention (`checkpoint-store.ts`):**
- Added `validateCheckpointId()` that rejects any ID not matching `[a-zA-Z0-9_-]` with a 64-char length cap
- Added resolved path verification (`path.resolve` prefix check) as defense-in-depth

**Resource exhaustion limits:**
- 5 MB cap on serialized checkpoint data (applies to all three store backends)
- 5 MB cap on `elements`, `json`, and `data` tool inputs in `server.ts`
- `FileCheckpointStore` now prunes oldest checkpoints beyond 100 entries (matching the TTL that `RedisCheckpointStore` already has)
- `MemoryCheckpointStore` evicts oldest entry when exceeding limit

**No breaking changes** -- server-generated checkpoint IDs are already hex UUIDs (`crypto.randomUUID().replace(/-/g, "").slice(0, 18)`) which pass the new validation. The size limits are generous enough for normal usage.

## Testing

- `npx tsc --noEmit` passes with no type errors
- Verified that server-generated checkpoint IDs (18-char hex strings) pass validation
- Verified that traversal payloads like `../../etc/passwd` and `../../../tmp/evil` are rejected