### PR TITLE
feat(app): add PNG export — copy to clipboard and save to Downloads

### DIFF
--- a/api/download/[id].ts
+++ b/api/download/[id].ts
@@ -1,4 +1,4 @@
-import { createVercelPngStore, RedisPngStore } from "../../src/png-store.js";
+import { createVercelPngStore } from "../../src/png-store.js";
 
 const store = createVercelPngStore();
 
@@ -12,11 +12,7 @@ export async function GET(request: Request) {
     });
   }
 
-  // Redis store needs async load
-  const entry = store instanceof RedisPngStore
-    ? await store.loadAsync(id)
-    : store.load(id);
-
+  const entry = await store.load(id);
   if (!entry) {
     return new Response(JSON.stringify({ error: "Not found or expired" }), {
       status: 404,
@@ -24,7 +20,7 @@ export async function GET(request: Request) {
     });
   }
 
-  store.delete(id);
+  await store.delete(id);
 
   return new Response(entry.data, {
     headers: {

--- a/api/download/[id].ts
+++ b/api/download/[id].ts
@@ -1,0 +1,36 @@
+import { createVercelPngStore, RedisPngStore } from "../../src/png-store.js";
+
+const store = createVercelPngStore();
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const id = url.pathname.split("/").pop();
+  if (!id || !/^[a-zA-Z0-9]+$/.test(id)) {
+    return new Response(JSON.stringify({ error: "Invalid ID" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Redis store needs async load
+  const entry = store instanceof RedisPngStore
+    ? await store.loadAsync(id)
+    : store.load(id);
+
+  if (!entry) {
+    return new Response(JSON.stringify({ error: "Not found or expired" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  store.delete(id);
+
+  return new Response(entry.data, {
+    headers: {
+      "Content-Type": "image/png",
+      "Content-Disposition": `attachment; filename="${entry.filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,14 +1,22 @@
 import { createMcpHandler } from "mcp-handler";
 import path from "node:path";
 import { createVercelStore } from "../src/checkpoint-store.js";
+import { createVercelPngStore } from "../src/png-store.js";
 import { registerTools } from "../src/server.js";
 
 const store = createVercelStore();
+const pngStore = createVercelPngStore();
+
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : "http://localhost:3001";
 
 const mcpHandler = createMcpHandler(
   (server) => {
     const distDir = path.join(process.cwd(), "dist");
-    registerTools(server, distDir, store);
+    registerTools(server, distDir, store, { pngStore, baseUrl });
   },
   { serverInfo: { name: "Excalidraw", version: "1.0.0" } },
   { basePath: "", maxDuration: 60, sessionIdGenerator: undefined },

--- a/src/global.css
+++ b/src/global.css
@@ -104,11 +104,13 @@ body {
   right: 8px;
   z-index: 100;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.2s ease;
 }
 
 .main:hover .toolbar {
   opacity: 1;
+  pointer-events: auto;
 }
 
 /* Fullscreen button */

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,14 +29,14 @@ export async function startStreamableHTTPServer(
   app.use(cors());
 
   // PNG download endpoint — serves stored PNGs as file downloads
-  app.get("/download/:id", (req: Request, res: Response) => {
+  app.get("/download/:id", async (req: Request, res: Response) => {
     const id = req.params.id as string;
-    const entry = pngStore.load(id);
+    const entry = await pngStore.load(id);
     if (!entry) {
       res.status(404).json({ error: "Not found or expired" });
       return;
     }
-    pngStore.delete(id);
+    await pngStore.delete(id);
     res.setHeader("Content-Type", "image/png");
     res.setHeader("Content-Disposition", `attachment; filename="${entry.filename}"`);
     res.send(entry.data);

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import cors from "cors";
 import type { Request, Response } from "express";
 import { FileCheckpointStore } from "./checkpoint-store.js";
+import { MemoryPngStore } from "./png-store.js";
 import { createServer } from "./server.js";
 
 /**
@@ -20,11 +21,26 @@ import { createServer } from "./server.js";
  */
 export async function startStreamableHTTPServer(
   createServer: () => McpServer,
+  pngStore: MemoryPngStore,
 ): Promise<void> {
   const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
+
+  // PNG download endpoint — serves stored PNGs as file downloads
+  app.get("/download/:id", (req: Request, res: Response) => {
+    const id = req.params.id as string;
+    const entry = pngStore.load(id);
+    if (!entry) {
+      res.status(404).json({ error: "Not found or expired" });
+      return;
+    }
+    pngStore.delete(id);
+    res.setHeader("Content-Type", "image/png");
+    res.setHeader("Content-Disposition", `attachment; filename="${entry.filename}"`);
+    res.send(entry.data);
+  });
 
   app.all("/mcp", async (req: Request, res: Response) => {
     const server = createServer();
@@ -82,11 +98,17 @@ export async function startStdioServer(
 
 async function main() {
   const store = new FileCheckpointStore();
-  const factory = () => createServer(store);
+  const pngStore = new MemoryPngStore();
+
   if (process.argv.includes("--stdio")) {
+    // stdio mode: no HTTP server, save_png falls back to ~/Downloads
+    const factory = () => createServer(store);
     await startStdioServer(factory);
   } else {
-    await startStreamableHTTPServer(factory);
+    const port = parseInt(process.env.PORT ?? "3001", 10);
+    const baseUrl = `http://localhost:${port}`;
+    const factory = () => createServer(store, { pngStore, baseUrl });
+    await startStreamableHTTPServer(factory, pngStore);
   }
 }
 

--- a/src/mcp-app.tsx
+++ b/src/mcp-app.tsx
@@ -145,12 +145,14 @@ const CheckIcon = () => (
 
 async function copyPngToClipboard(elements: any[]): Promise<boolean> {
   if (!elements?.length) return false;
-  const blob = await exportToBlob({
+  // Pass the blob promise directly to ClipboardItem to retain user-activation
+  // context on Safari (awaiting exportToBlob first would expire it)
+  const blobPromise = exportToBlob({
     elements: elements as any,
     appState: { exportBackground: true } as any,
     files: null,
   });
-  await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+  await navigator.clipboard.write([new ClipboardItem({ "image/png": blobPromise })]);
   return true;
 }
 

--- a/src/mcp-app.tsx
+++ b/src/mcp-app.tsx
@@ -1,6 +1,6 @@
 import { useApp } from "@modelcontextprotocol/ext-apps/react";
 import type { App } from "@modelcontextprotocol/ext-apps";
-import {  Excalidraw, exportToSvg, convertToExcalidrawElements, restore, CaptureUpdateAction, FONT_FAMILY, serializeAsJSON, MainMenu } from "@excalidraw/excalidraw";
+import {  Excalidraw, exportToSvg, exportToBlob, convertToExcalidrawElements, restore, CaptureUpdateAction, FONT_FAMILY, serializeAsJSON, MainMenu } from "@excalidraw/excalidraw";
 import morphdom from "morphdom";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { initPencilAudio, playStroke } from "./pencil-audio";
@@ -122,6 +122,83 @@ const ExternalLinkIcon = () => (
   </svg>
 );
 
+const DownloadIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M2.667 10v2.667c0 .368.298.666.666.666h9.334a.667.667 0 0 0 .666-.666V10" />
+    <path d="M8 2.667V10.667" />
+    <path d="M5.333 8L8 10.667L10.667 8" />
+  </svg>
+);
+
+const CopyIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="5.333" y="5.333" width="8" height="8" rx="1" />
+    <path d="M2.667 10.667H2a.667.667 0 0 1-.667-.667V2A.667.667 0 0 1 2 1.333h8a.667.667 0 0 1 .667.667v.667" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3.333 8.667L6 11.333L12.667 4.667" />
+  </svg>
+);
+
+async function copyPngToClipboard(elements: any[]): Promise<boolean> {
+  if (!elements?.length) return false;
+  const blob = await exportToBlob({
+    elements: elements as any,
+    appState: { exportBackground: true } as any,
+    files: null,
+  });
+  await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+  return true;
+}
+
+async function downloadAsPng(elements: any[], app?: App): Promise<{ path?: string } | null> {
+  if (!elements?.length || !app) return null;
+  try {
+    const blob = await exportToBlob({
+      elements: elements as any,
+      appState: { exportBackground: true } as any,
+      files: null,
+    });
+
+    // Convert blob to base64 for upload to server
+    const reader = new FileReader();
+    const base64 = await new Promise<string>((resolve, reject) => {
+      reader.onload = () => {
+        const result = reader.result as string;
+        resolve(result.replace(/^data:[^;]+;base64,/, ""));
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+
+    // Upload to server — returns either a download URL (HTTP mode) or a file path (stdio mode)
+    const result = await app.callServerTool({
+      name: "upload_png",
+      arguments: { data: base64 },
+    });
+
+    if (result.isError) {
+      app.sendLog({ level: "error", logger: "Excalidraw", data: `upload_png failed: ${JSON.stringify(result.content)}` });
+      return null;
+    }
+
+    const response = JSON.parse((result.content[0] as any).text);
+    if (response.url) {
+      // HTTP mode: open download URL in browser
+      await app.openLink({ url: response.url });
+      return {};
+    }
+    // stdio mode: file was saved to ~/Downloads
+    return { path: response.path };
+  } catch (err) {
+    if (app) app.sendLog({ level: "error", logger: "Excalidraw", data: `PNG export failed: ${err}` });
+    return null;
+  }
+}
+
 async function shareToExcalidraw(data: {elements: any[], appState: any, files: any}, app: App) {
   try {
     if (!data.elements?.length) return;
@@ -145,6 +222,75 @@ async function shareToExcalidraw(data: {elements: any[], appState: any, files: a
   } catch (err) {
     fsLog(`shareToExcalidraw error: ${err}`);
   }
+}
+
+function PngButton({ getElements, app }: { getElements: () => any[]; app: App }) {
+  const [state, setState] = useState<"idle" | "saving" | "saved">("idle");
+  const [savedPath, setSavedPath] = useState<string | null>(null);
+
+  const handleClick = async () => {
+    setState("saving");
+    setSavedPath(null);
+    try {
+      const result = await downloadAsPng(getElements(), app);
+      if (result) {
+        setState("saved");
+        setSavedPath(result.path ?? null);
+        setTimeout(() => { setState("idle"); setSavedPath(null); }, 3000);
+      } else {
+        setState("idle");
+      }
+    } catch {
+      setState("idle");
+    }
+  };
+
+  const label = state === "saving" ? "Saving…"
+    : state === "saved" ? (savedPath ? `Saved to Downloads` : "Saved!")
+    : "PNG";
+
+  return (
+    <button
+      className="app-button"
+      style={{ display: "flex", alignItems: "center", gap: 5, width: "auto", padding: "0 10px" }}
+      onClick={handleClick}
+      disabled={state === "saving"}
+      title={savedPath ?? "Save PNG to Downloads"}
+    >
+      <DownloadIcon />
+      <span style={{ fontSize: "0.75rem", fontWeight: 400 }}>{label}</span>
+    </button>
+  );
+}
+
+function CopyPngButton({ getElements }: { getElements: () => any[] }) {
+  const [state, setState] = useState<"idle" | "copying" | "copied">("idle");
+
+  const handleClick = async () => {
+    setState("copying");
+    try {
+      await copyPngToClipboard(getElements());
+      setState("copied");
+      setTimeout(() => setState("idle"), 2000);
+    } catch {
+      setState("idle");
+    }
+  };
+
+  return (
+    <button
+      className="app-button"
+      style={{ display: "flex", alignItems: "center", gap: 5, width: "auto", padding: "0 10px" }}
+      onClick={handleClick}
+      disabled={state === "copying"}
+      title="Copy PNG to clipboard"
+    >
+      {state === "copied" ? <CheckIcon /> : <CopyIcon />}
+      <span style={{ fontSize: "0.75rem", fontWeight: 400 }}>
+        {state === "copying" ? "Copying…" : state === "copied" ? "Copied!" : "Copy PNG"}
+      </span>
+    </button>
+  );
 }
 
 function ShareButton({ onConfirm }: { onConfirm: () => Promise<void> }) {
@@ -842,6 +988,10 @@ export function ExcalidrawAppCore({ app }: { app: App }) {
                 }}
               />
 
+          <CopyPngButton getElements={() => elements} />
+
+          <PngButton getElements={() => elements} app={app} />
+
           <button
             className="app-button"
             onClick={toggleFullscreen}
@@ -867,17 +1017,21 @@ export function ExcalidrawAppCore({ app }: { app: App }) {
             theme="light"
             onChange={(els) => onEditorChange(app, els)}
             renderTopRightUI={() => (
-              <ShareButton
-                onConfirm={async () => {
-                  if (excalidrawApi) {
-                    const elements = excalidrawApi.getSceneElements();
-                    const appState = excalidrawApi.getAppState();
-                    const files = excalidrawApi.getFiles();
+              <>
+                <ShareButton
+                  onConfirm={async () => {
+                    if (excalidrawApi) {
+                      const elements = excalidrawApi.getSceneElements();
+                      const appState = excalidrawApi.getAppState();
+                      const files = excalidrawApi.getFiles();
 
-                    await shareToExcalidraw({ elements, appState, files }, app);
-                  }
-                }}
-              />
+                      await shareToExcalidraw({ elements, appState, files }, app);
+                    }
+                  }}
+                />
+                <CopyPngButton getElements={() => excalidrawApi?.getSceneElements() ?? []} />
+                <PngButton getElements={() => excalidrawApi?.getSceneElements() ?? []} app={app} />
+              </>
             )}
           >
             <MainMenu>

--- a/src/png-store.ts
+++ b/src/png-store.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-interface PngEntry {
+export interface PngEntry {
   data: Buffer;
   filename: string;
   createdAt: number;
@@ -10,13 +10,13 @@ interface PngEntry {
 const TTL_MS = 5 * 60 * 1000;
 /** Max stored PNGs before rejecting new uploads. */
 const MAX_ENTRIES = 50;
-/** Max PNG size: 2 MB. */
-export const MAX_PNG_BYTES = 2 * 1024 * 1024;
+/** Max PNG size: 4 MB (under Vercel's 4.5 MB payload limit). */
+export const MAX_PNG_BYTES = 4 * 1024 * 1024;
 
 export interface PngStore {
-  save(data: Buffer, filename: string): string;
-  load(id: string): PngEntry | null;
-  delete(id: string): void;
+  save(data: Buffer, filename: string): Promise<string>;
+  load(id: string): Promise<PngEntry | null>;
+  delete(id: string): Promise<void>;
 }
 
 export class MemoryPngStore implements PngStore {
@@ -31,10 +31,9 @@ export class MemoryPngStore implements PngStore {
     }
   }
 
-  save(data: Buffer, filename: string): string {
+  async save(data: Buffer, filename: string): Promise<string> {
     this.sweep();
     if (this.entries.size >= MAX_ENTRIES) {
-      // Remove oldest
       const oldest = this.entries.keys().next().value;
       if (oldest !== undefined) this.entries.delete(oldest);
     }
@@ -43,12 +42,12 @@ export class MemoryPngStore implements PngStore {
     return id;
   }
 
-  load(id: string): PngEntry | null {
+  async load(id: string): Promise<PngEntry | null> {
     this.sweep();
     return this.entries.get(id) ?? null;
   }
 
-  delete(id: string): void {
+  async delete(id: string): Promise<void> {
     this.entries.delete(id);
   }
 }
@@ -56,7 +55,6 @@ export class MemoryPngStore implements PngStore {
 /** Redis-backed PNG store for Vercel (base64 string stored with TTL). */
 export class RedisPngStore implements PngStore {
   private redis: any = null;
-  private pendingOps = new Map<string, Promise<void>>();
 
   private async getRedis() {
     if (!this.redis) {
@@ -69,33 +67,17 @@ export class RedisPngStore implements PngStore {
     return this.redis;
   }
 
-  save(data: Buffer, filename: string): string {
+  async save(data: Buffer, filename: string): Promise<string> {
     const id = crypto.randomUUID().replace(/-/g, "").slice(0, 18);
-    // Fire and forget — store asynchronously, return id immediately
-    const op = this.getRedis().then((redis: any) =>
-      redis.set(`png:${id}`, JSON.stringify({
-        data: data.toString("base64"),
-        filename,
-      }), { ex: 300 }) // 5 min TTL
-    );
-    this.pendingOps.set(id, op);
-    op.finally(() => this.pendingOps.delete(id));
+    const redis = await this.getRedis();
+    await redis.set(`png:${id}`, JSON.stringify({
+      data: data.toString("base64"),
+      filename,
+    }), { ex: 300 }); // 5 min TTL
     return id;
   }
 
-  load(_id: string): PngEntry | null {
-    // Synchronous interface doesn't work for Redis — use loadAsync instead
-    return null;
-  }
-
-  delete(id: string): void {
-    this.getRedis().then((redis: any) => redis.del(`png:${id}`)).catch(() => {});
-  }
-
-  async loadAsync(id: string): Promise<PngEntry | null> {
-    // Wait for pending save if it exists
-    const pending = this.pendingOps.get(id);
-    if (pending) await pending;
+  async load(id: string): Promise<PngEntry | null> {
     try {
       const redis = await this.getRedis();
       const raw = await redis.get(`png:${id}`);
@@ -109,6 +91,13 @@ export class RedisPngStore implements PngStore {
     } catch {
       return null;
     }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      const redis = await this.getRedis();
+      await redis.del(`png:${id}`);
+    } catch {}
   }
 }
 

--- a/src/png-store.ts
+++ b/src/png-store.ts
@@ -1,0 +1,120 @@
+import crypto from "node:crypto";
+
+interface PngEntry {
+  data: Buffer;
+  filename: string;
+  createdAt: number;
+}
+
+/** TTL for stored PNGs: 5 minutes. */
+const TTL_MS = 5 * 60 * 1000;
+/** Max stored PNGs before rejecting new uploads. */
+const MAX_ENTRIES = 50;
+/** Max PNG size: 2 MB. */
+export const MAX_PNG_BYTES = 2 * 1024 * 1024;
+
+export interface PngStore {
+  save(data: Buffer, filename: string): string;
+  load(id: string): PngEntry | null;
+  delete(id: string): void;
+}
+
+export class MemoryPngStore implements PngStore {
+  private entries = new Map<string, PngEntry>();
+
+  private sweep() {
+    const now = Date.now();
+    for (const [id, entry] of this.entries) {
+      if (now - entry.createdAt > TTL_MS) {
+        this.entries.delete(id);
+      }
+    }
+  }
+
+  save(data: Buffer, filename: string): string {
+    this.sweep();
+    if (this.entries.size >= MAX_ENTRIES) {
+      // Remove oldest
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+    const id = crypto.randomUUID().replace(/-/g, "").slice(0, 18);
+    this.entries.set(id, { data, filename, createdAt: Date.now() });
+    return id;
+  }
+
+  load(id: string): PngEntry | null {
+    this.sweep();
+    return this.entries.get(id) ?? null;
+  }
+
+  delete(id: string): void {
+    this.entries.delete(id);
+  }
+}
+
+/** Redis-backed PNG store for Vercel (base64 string stored with TTL). */
+export class RedisPngStore implements PngStore {
+  private redis: any = null;
+  private pendingOps = new Map<string, Promise<void>>();
+
+  private async getRedis() {
+    if (!this.redis) {
+      const { Redis } = await import("@upstash/redis");
+      const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+      const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+      if (!url || !token) throw new Error("Missing Redis env vars");
+      this.redis = new Redis({ url, token });
+    }
+    return this.redis;
+  }
+
+  save(data: Buffer, filename: string): string {
+    const id = crypto.randomUUID().replace(/-/g, "").slice(0, 18);
+    // Fire and forget — store asynchronously, return id immediately
+    const op = this.getRedis().then((redis: any) =>
+      redis.set(`png:${id}`, JSON.stringify({
+        data: data.toString("base64"),
+        filename,
+      }), { ex: 300 }) // 5 min TTL
+    );
+    this.pendingOps.set(id, op);
+    op.finally(() => this.pendingOps.delete(id));
+    return id;
+  }
+
+  load(_id: string): PngEntry | null {
+    // Synchronous interface doesn't work for Redis — use loadAsync instead
+    return null;
+  }
+
+  delete(id: string): void {
+    this.getRedis().then((redis: any) => redis.del(`png:${id}`)).catch(() => {});
+  }
+
+  async loadAsync(id: string): Promise<PngEntry | null> {
+    // Wait for pending save if it exists
+    const pending = this.pendingOps.get(id);
+    if (pending) await pending;
+    try {
+      const redis = await this.getRedis();
+      const raw = await redis.get(`png:${id}`);
+      if (!raw) return null;
+      const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+      return {
+        data: Buffer.from(parsed.data, "base64"),
+        filename: parsed.filename,
+        createdAt: 0,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function createVercelPngStore(): PngStore {
+  if (process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL) {
+    return new RedisPngStore();
+  }
+  return new MemoryPngStore();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -671,7 +671,7 @@ However, if the user wants to edit something on this diagram "${checkpointId}", 
           }
           const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
           const filename = `excalidraw-${timestamp}.png`;
-          const id = pngStore.save(buf, filename);
+          const id = await pngStore.save(buf, filename);
           const url = `${baseUrl}/download/${id}`;
           return { content: [{ type: "text", text: JSON.stringify({ url }) }] };
         } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,10 +3,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { deflateSync } from "node:zlib";
 import { z } from "zod/v4";
 import type { CheckpointStore } from "./checkpoint-store.js";
+import type { PngStore } from "./png-store.js";
+import { MAX_PNG_BYTES } from "./png-store.js";
 
 /** Maximum allowed size for element/data input strings (5 MB). */
 const MAX_INPUT_BYTES = 5 * 1024 * 1024;
@@ -398,7 +401,7 @@ Use the Primary Colors from above — they're bright enough on dark backgrounds.
  * Registers all Excalidraw tools and resources on the given McpServer.
  * Shared between local (main.ts) and Vercel (api/mcp.ts) entry points.
  */
-export function registerTools(server: McpServer, distDir: string, store: CheckpointStore): void {
+export function registerTools(server: McpServer, distDir: string, store: CheckpointStore, opts?: { pngStore?: PngStore; baseUrl?: string }): void {
   const resourceUri = "ui://excalidraw/mcp-app.html";
 
   // ============================================================
@@ -647,6 +650,63 @@ However, if the user wants to edit something on this diagram "${checkpointId}", 
     },
   );
 
+  // ============================================================
+  // Tool 6: upload_png (private — widget only, for PNG export)
+  // ============================================================
+  if (opts?.pngStore && opts?.baseUrl) {
+    const pngStore = opts.pngStore;
+    const baseUrl = opts.baseUrl;
+    registerAppTool(server,
+      "upload_png",
+      {
+        description: "Upload PNG for download. Returns a download URL.",
+        inputSchema: { data: z.string().describe("Base64-encoded PNG data") },
+        _meta: { ui: { visibility: ["app"] } },
+      },
+      async ({ data }): Promise<CallToolResult> => {
+        try {
+          const buf = Buffer.from(data, "base64");
+          if (buf.length > MAX_PNG_BYTES) {
+            return { content: [{ type: "text", text: `PNG exceeds ${MAX_PNG_BYTES} byte limit.` }], isError: true };
+          }
+          const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+          const filename = `excalidraw-${timestamp}.png`;
+          const id = pngStore.save(buf, filename);
+          const url = `${baseUrl}/download/${id}`;
+          return { content: [{ type: "text", text: JSON.stringify({ url }) }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `upload failed: ${(err as Error).message}` }], isError: true };
+        }
+      },
+    );
+  } else {
+    // Fallback for stdio mode: save directly to ~/Downloads
+    registerAppTool(server,
+      "upload_png",
+      {
+        description: "Save PNG to Downloads folder.",
+        inputSchema: { data: z.string().describe("Base64-encoded PNG data") },
+        _meta: { ui: { visibility: ["app"] } },
+      },
+      async ({ data }): Promise<CallToolResult> => {
+        try {
+          const buf = Buffer.from(data, "base64");
+          if (buf.length > MAX_PNG_BYTES) {
+            return { content: [{ type: "text", text: `PNG exceeds ${MAX_PNG_BYTES} byte limit.` }], isError: true };
+          }
+          const downloadsDir = path.join(os.homedir(), "Downloads");
+          const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+          const filename = `excalidraw-${timestamp}.png`;
+          const filePath = path.join(downloadsDir, filename);
+          await fs.writeFile(filePath, buf);
+          return { content: [{ type: "text", text: JSON.stringify({ path: filePath }) }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `save failed: ${(err as Error).message}` }], isError: true };
+        }
+      },
+    );
+  }
+
   // CSP: allow Excalidraw to load fonts from esm.sh
   const cspMeta = {
     ui: {
@@ -686,11 +746,11 @@ However, if the user wants to edit something on this diagram "${checkpointId}", 
  * Creates a new MCP server instance with Excalidraw drawing tools.
  * Used by local entry point (main.ts) and Docker deployments.
  */
-export function createServer(store: CheckpointStore): McpServer {
+export function createServer(store: CheckpointStore, opts?: { pngStore?: PngStore; baseUrl?: string }): McpServer {
   const server = new McpServer({
     name: "Excalidraw",
     version: "1.0.0",
   });
-  registerTools(server, DIST_DIR, store);
+  registerTools(server, DIST_DIR, store, opts);
   return server;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,8 @@
   "rewrites": [
     { "source": "/mcp", "destination": "/api/mcp" },
     { "source": "/sse", "destination": "/api/mcp" },
-    { "source": "/message", "destination": "/api/mcp" }
+    { "source": "/message", "destination": "/api/mcp" },
+    { "source": "/download/:id", "destination": "/api/download/:id" }
   ],
   "headers": [
     {


### PR DESCRIPTION
https://github.com/user-attachments/assets/c47b7d98-d414-4a46-993e-363c647fe588
## Summary
- Adds **Copy PNG** button that exports the diagram as a PNG blob and copies it to the clipboard via the Clipboard API
- Adds **Download PNG** button that uploads the PNG to a server-side store (`PngStore`) and returns a download URL, with button state feedback (idle → saving → saved with path)
- New `PngStore` abstraction with memory and Redis (Upstash KV) implementations, 5-minute TTL, and `MAX_PNG_BYTES` size guard
- Vercel download endpoint (`api/download/[id].ts`) serves stored PNGs with proper `Content-Disposition` headers

## Test plan
- [ ] Create a diagram, click **Copy PNG** — paste into another app and verify image content
- [ ] Click **Download PNG** — verify file appears in Downloads with correct diagram content
- [ ] Verify button states transition: idle → saving → saved (with file path shown)
- [ ] Test in fullscreen mode — both buttons should remain functional
- [ ] Test with a large diagram to verify `MAX_PNG_BYTES` limit is enforced
- [ ] Test immediately after streaming completes to verify no race with final render

Closes #31 