### PR TITLE
fix: respect host safeAreaInsets in fullscreen mode

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -70,7 +70,9 @@ body {
   position: relative;
 }
 
-/* Fullscreen mode */
+/* Fullscreen mode — canvas fills edge-to-edge, but Excalidraw's own UI
+   (toolbars, menus) stays inside the host's safe area so it isn't hidden
+   behind mobile chrome (navbar, chat input, home indicator). */
 .main.fullscreen {
   position: fixed;
   top: 0;
@@ -79,10 +81,24 @@ body {
   bottom: 0;
   background: var(--bg-color, #ffffff);
   z-index: 9999;
+  --safe-area-inset-top: 0px;
+  --safe-area-inset-right: 0px;
+  --safe-area-inset-bottom: 0px;
+  --safe-area-inset-left: 0px;
 }
 
 .main.fullscreen .excalidraw-container {
   height: 100%;
+}
+
+/* Push Excalidraw's native UI inside the safe area. The canvas itself
+   stays full-bleed; only the interactive chrome respects the insets. */
+.main.fullscreen .excalidraw .layer-ui__wrapper {
+  padding-top: var(--safe-area-inset-top);
+  padding-right: var(--safe-area-inset-right);
+  padding-bottom: var(--safe-area-inset-bottom);
+  padding-left: var(--safe-area-inset-left);
+  box-sizing: border-box;
 }
 
 /* Hide library button in fullscreen editor */

--- a/src/mcp-app.tsx
+++ b/src/mcp-app.tsx
@@ -656,6 +656,7 @@ export function ExcalidrawAppCore({ app }: { app: App }) {
   const [toolInput, setToolInput] = useState<any>(null);
   const [inputIsFinal, setInputIsFinal] = useState(false);
   const [displayMode, setDisplayMode] = useState<"inline" | "fullscreen">("inline");
+  const [safeAreaInsets, setSafeAreaInsets] = useState<{ top: number; right: number; bottom: number; left: number } | null>(null);
   const [elements, setElements] = useState<any[]>([]);
   const [userEdits, setUserEdits] = useState<any[] | null>(null);
   const [containerHeight, setContainerHeight] = useState<number | null>(null);
@@ -773,13 +774,17 @@ export function ExcalidrawAppCore({ app }: { app: App }) {
     appRef.current = app;
     _logFn = (msg) => { try { app.sendLog({ level: "info", logger: "FS", data: msg }); } catch {} };
 
-    // Capture initial container dimensions
-    const initDims = app.getHostContext()?.containerDimensions as any;
-    if (initDims?.height) setContainerHeight(initDims.height);
+    // Capture initial container dimensions + safe area
+    const initCtx = app.getHostContext() as any;
+    if (initCtx?.containerDimensions?.height) setContainerHeight(initCtx.containerDimensions.height);
+    if (initCtx?.safeAreaInsets) setSafeAreaInsets(initCtx.safeAreaInsets);
 
     app.onhostcontextchanged = (ctx: any) => {
       if (ctx.containerDimensions?.height) {
         setContainerHeight(ctx.containerDimensions.height);
+      }
+      if (ctx.safeAreaInsets) {
+        setSafeAreaInsets(ctx.safeAreaInsets);
       }
       if (ctx.displayMode) {
         fsLog(`hostContextChanged: displayMode=${ctx.displayMode}`);
@@ -829,7 +834,18 @@ export function ExcalidrawAppCore({ app }: { app: App }) {
   }, [app]);
 
   return (
-    <main className={`main${displayMode === "fullscreen" ? " fullscreen" : ""}`} style={displayMode === "fullscreen" && containerHeight ? { height: containerHeight } : undefined}>
+    <main
+      className={`main${displayMode === "fullscreen" ? " fullscreen" : ""}`}
+      style={displayMode === "fullscreen" ? {
+        ...(containerHeight ? { height: containerHeight } : {}),
+        ...(safeAreaInsets ? {
+          "--safe-area-inset-top": `${safeAreaInsets.top}px`,
+          "--safe-area-inset-right": `${safeAreaInsets.right}px`,
+          "--safe-area-inset-bottom": `${safeAreaInsets.bottom}px`,
+          "--safe-area-inset-left": `${safeAreaInsets.left}px`,
+        } as React.CSSProperties : {}),
+      } : undefined}
+    >
       {displayMode === "inline" && (
         <div className="toolbar">
           <ShareButton


### PR DESCRIPTION
On mobile hosts, the fullscreen container fills the WebView edge-to-edge under host chrome (navigation bar, chat input, home indicator). Excalidraw's UI wrapper was pinned to the container edges, placing toolbars behind host chrome where they can't be tapped.

## What changed

- Read `safeAreaInsets` from host context (initial + `onhostcontextchanged`)
- Expose as CSS custom properties on the `<main>` element
- Pad `.layer-ui__wrapper` so Excalidraw's native UI stays inside the safe area while the canvas stays full-bleed

## Testing

Tested on Android mobile host with edge-to-edge fullscreen — hamburger menu + undo/redo buttons now sit above the chat input bar instead of behind the gesture nav strip.

The `.layer-ui__wrapper` selector is Excalidraw-library-internal; worth verifying against the pinned library version.