### PR TITLE
Fix directory name in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "excalidraw": {
       "command": "node",
-      "args": ["/path/to/excalidraw-mcp-app/dist/index.js", "--stdio"]
+      "args": ["/path/to/excalidraw-mcp/dist/index.js", "--stdio"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For apps that don't yet have an official integration, you can add a custom MCP /
 
 ```bash
 git clone https://github.com/excalidraw/excalidraw-mcp.git
-cd excalidraw-mcp-app
+cd excalidraw-mcp
 pnpm install && pnpm run build
 ```
 


### PR DESCRIPTION
Update directory name in build instructions. Because the repo name is excalidraw-mcp, git clones the repo to a new `excalidraw-mcp` directory, not `excalidraw-mcp-app`. So the cd command doesn't work out of the box. 

An alternative approach could be adding excalidraw-mcp-app as the target directory argument in the git clone command. Dealers choice.