### PR TITLE
Add Claude Code config example with required "type": "http"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Works with any client that supports [MCP Apps](https://modelcontextprotocol.io/d
 
 For apps that don't yet have an official integration, you can add a custom MCP / connector (naming can vary between apps).
 
+**Claude Code** — add to `~/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "excalidraw": {
+      "type": "http",
+      "url": "https://mcp.excalidraw.com"
+    }
+  }
+}
+```
+
 ### Local
 
 **Option A: Download Extension**


### PR DESCRIPTION
## Problem

Claude Code requires `"type": "http"` in `.mcp.json` for HTTP-based MCP servers. Without it, the config silently fails schema validation — tools don't appear and no error is shown. The `/doctor` command reports: "Does not adhere to MCP server configuration schema".

## Fix

Added a Claude Code configuration example under the Remote install section showing the correct config with `"type": "http"`:

```json
{
  "mcpServers": {
    "excalidraw": {
      "type": "http",
      "url": "https://mcp.excalidraw.com"
    }
  }
}
```

## Related

- Fixes #64
- Same issue for Excalidraw Plus docs: #11107 (excalidraw/excalidraw)
