### PR TITLE
Fix: Change create_view elements from JSON string to typed array

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ vite.config.dev.ts → Dev-only vite config (resolves from node_modules, no esm.
 Returns a cheat sheet with element format, color palettes, coordinate tips, and examples. The model should call this before `create_view`.
 
 ### `create_view` (UI tool)
-Takes `elements` — a JSON string of standard Excalidraw elements. The widget parses partial JSON during streaming and renders via `exportToSvg` + morphdom diffing. No Excalidraw React canvas component — pure SVG rendering.
+Takes `elements` — an array of standard Excalidraw element objects. Zod validates the array structure (no manual JSON parsing needed). The widget renders via `exportToSvg` + morphdom diffing. No Excalidraw React canvas component — pure SVG rendering.
 
 **Screenshot as model context:** After final render, the SVG is captured as a 512px-max PNG and sent via `app.updateModelContext()` so the model can see the diagram and iterate on user feedback.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -426,29 +426,22 @@ export function registerTools(server: McpServer, distDir: string, store: Checkpo
 Elements stream in one by one with draw-on animations.
 Call read_me first to learn the element format.`,
       inputSchema: z.object({
-        elements: z.string().describe(
-          "JSON array string of Excalidraw elements. Must be valid JSON — no comments, no trailing commas. Keep compact. Call read_me first for format reference."
+        elements: z.array(z.record(z.any())).describe(
+          "Array of Excalidraw elements. Each element is an object with at least a type field. Call read_me first for format reference."
         ),
       }),
       annotations: { readOnlyHint: true },
       _meta: { ui: { resourceUri } },
     },
     async ({ elements }): Promise<CallToolResult> => {
-      if (elements.length > MAX_INPUT_BYTES) {
+      const serialized = JSON.stringify(elements);
+      if (serialized.length > MAX_INPUT_BYTES) {
         return {
           content: [{ type: "text", text: `Elements input exceeds ${MAX_INPUT_BYTES} byte limit. Reduce the number of elements or use checkpoints to build incrementally.` }],
           isError: true,
         };
       }
-      let parsed: any[];
-      try {
-        parsed = JSON.parse(elements);
-      } catch (e) {
-        return {
-          content: [{ type: "text", text: `Invalid JSON in elements: ${(e as Error).message}. Ensure no comments, no trailing commas, and proper quoting.` }],
-          isError: true,
-        };
-      }
+      const parsed: any[] = elements;
 
       // Resolve restoreCheckpoint references and save fully resolved state
       const restoreEl = parsed.find((el: any) => el.type === "restoreCheckpoint");


### PR DESCRIPTION
## Problem

`create_view` accepts `elements` as `z.string()` — a raw JSON array string. Models frequently generate invalid JSON in this string (trailing commas, unquoted keys, comments), causing silent "Invalid JSON in elements" errors. Since the schema doesn't enforce structure, strict tool use features (Claude structured outputs, ChatGPT function calling) can't help.

## Fix

Changed `elements` from `z.string()` to `z.array(z.record(z.any()))`. This lets Zod validate the array structure directly, enabling structured output / strict tool use to generate valid input.

**Before:**
```json
{
  "elements": "[{"type": "rectangle", "x": 10}]"
}
```

**After:**
```json
{
  "elements": [{"type": "rectangle", "x": 10}]
}
```

The widget (`mcp-app.tsx` line 432) already handles both string and array inputs via `typeof` check, so no frontend changes needed.

## Changes

- `src/server.ts`: Changed schema from `z.string()` to `z.array(z.record(z.any()))`, removed manual JSON.parse block, updated size check to use `JSON.stringify(elements).length`
- `CLAUDE.md`: Updated create_view description

## Related

Fixes #56
