### PR TITLE
Fix directory path in README for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For apps that don't yet have an official integration, you can add a custom MCP /
 
 ```bash
 git clone https://github.com/excalidraw/excalidraw-mcp.git
-cd excalidraw-mcp-app
+cd excalidraw-mcp
 pnpm install && pnpm run build
 ```
 


### PR DESCRIPTION
Correct directory name in build instructions.