### PR TITLE
Add generic MIT license file

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 - present Excalidraw MCP App Server
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
-  "mcpServers": {
-    "excalidraw": {
-      "command": "node",
-      "args": ["/path/to/excalidraw-mcp-app/dist/index.js", "--stdio"]
-    }
-  }
+	"mcpServers": {
+		"excalidraw": {
+			"command": "node",
+			"args": ["/path/to/excalidraw-mcp-app/dist/index.js", "--stdio"]
+		}
+	}
 }
 ```
 
@@ -47,6 +47,7 @@ Restart Claude Desktop.
 ## Usage
 
 Example prompts:
+
 - "Draw a cute cat using excalidraw"
 - "Draw an architecture diagram showing a user connecting to an API server which talks to a database"
 
@@ -95,4 +96,4 @@ Built with [Excalidraw](https://github.com/excalidraw/excalidraw) — a virtual 
 
 ## License
 
-MIT
+[MIT](/LICENCE.txt)


### PR DESCRIPTION
This PR adds a generic MIT license file to the repository.

The README already indicates that the project is MIT licensed, but the repository was missing the actual license text. This change addresses issue #45 by adding the standard MIT license so the repo’s licensing is explicit and complete. If maintainers want different copyright wording or project-specific attribution, the file can be updated to their preferred form.

Fixes #45.